### PR TITLE
Python: execfile cannot be used in Python3

### DIFF
--- a/server/pvw-visualizer.py
+++ b/server/pvw-visualizer.py
@@ -86,7 +86,10 @@ import sys
 if '--virtual-env' in sys.argv:
   virtualEnvPath = sys.argv[sys.argv.index('--virtual-env') + 1]
   virtualEnv = virtualEnvPath + '/bin/activate_this.py'
-  execfile(virtualEnv, dict(__file__=virtualEnv))
+  if sys.version_info.major < 3:
+    execfile(virtualEnv, dict(__file__=virtualEnv))
+  else:
+    exec(open(virtualEnv).read(), {'__file__': virtualEnv})
 
 
 # import paraview modules.


### PR DESCRIPTION
Replace it for `exec(open(_file_).read(), ...)` when python version is 3